### PR TITLE
Fix CloudFront hijack checks

### DIFF
--- a/cinq_auditor_domain_hijacking/__init__.py
+++ b/cinq_auditor_domain_hijacking/__init__.py
@@ -67,18 +67,19 @@ class DomainHijackAuditor(BaseAuditor):
 
             for dist in dists:
                 for org in dist.origins:
-                    bucket = org.replace('.s3.amazonaws.com', '')
+                    if org['type'] == 's3':
+                        bucket = org['source'].replace('.s3.amazonaws.com', '')
 
-                    if bucket not in buckets:
-                        key = '{} ({})'.format(bucket, dist.type)
-                        issues.append({
-                            'key': key,
-                            'value': 'S3Bucket {} doesnt exist on any known account. Referenced by {} on {}'.format(
-                                bucket,
-                                dist.domain_name,
-                                dist.account,
-                            )
-                        })
+                        if bucket not in buckets:
+                            key = '{} ({})'.format(bucket, dist.type)
+                            issues.append({
+                                'key': key,
+                                'value': 'S3Bucket {} doesnt exist on any known account. Referenced by {} on {}'.format(
+                                    bucket,
+                                    dist.domain_name,
+                                    dist.account,
+                                )
+                            })
             # endregion
 
             # region Process new, old, fixed issue lists

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         'cloud-inquisitor~=1.0.0',
-        'cinq-collector-aws~=1.0.2',
+        'cinq-collector-aws~=1.0.3',
         'dnspython>=1.15.0',
     ],
     extras_require={


### PR DESCRIPTION
Fix the hijack checker to not assume all distributions use S3 origins, instead specifically check for the type of the origin source.