### PR TITLE
fix(S3Audit): Add a check for misconfigured S3 bucket CNAME

### DIFF
--- a/cinq_auditor_domain_hijacking/__init__.py
+++ b/cinq_auditor_domain_hijacking/__init__.py
@@ -241,6 +241,18 @@ class S3Audit(DomainAudit):
                                 zone.source
                             )
                         })
+
+                    if bucketName != record.name:
+                        issues.append({
+                            'key': '{}/{}'.format(zone.name, record.name),
+                            'value': 'Misconfigured CNAME to S3 for {}/{}/{}. Points to {} but should be {}'.format(
+                                zone.source,
+                                zone.name,
+                                record.name,
+                                bucketName,
+                                record.name
+                            )
+                        })
             elif type(record.value) == str:
                 bucketName, region = parse_bucket_info(record.value)
 


### PR DESCRIPTION
With CNAME'd buckets, the hostname and the bucket name must be the
same, however if the CNAME points to a different bucket which does
exist, the previous version of the auditor would not catch it correctly.

This update adds an additional check to ensure that the CNAME'd value
and the name of the bucket / hostname is the same.