### PR TITLE
feat: Reduce emails by adding an alert frequency setting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'cloud-inquisitor~=1.1.2',
+        'cloud-inquisitor~=1.1.17',
         'cinq-collector-aws~=1.1.0',
         'dnspython~=1.15.0',
     ],


### PR DESCRIPTION
In order to reduce the amount of emails coming when you have a long-lasting issue, you can now configure how often, in hours, you want alerts to be sent for existing issues